### PR TITLE
enable js to listen on an existing server

### DIFF
--- a/src/main/resources/yokejs/Yoke.js
+++ b/src/main/resources/yokejs/Yoke.js
@@ -69,11 +69,17 @@ JSYoke.prototype.set = function (key, value) {
 };
 
 JSYoke.prototype.listen = function (port, address) {
-    if (address === undefined) {
-        address = '0.0.0.0';
-    }
+    // check if port looks like an HTTP server as created by vertx.createHttpServer
+    if (typeof port === 'object' && port._to_java_server() instanceof org.vertx.java.core.http.HttpServer) {
+        // in that case pass it directly to the jYoke
+        this.jYoke.listen(port._to_java_server());
+    } else {
+        if (address === undefined) {
+            address = '0.0.0.0';
+        }
 
-    this.jYoke.listen(port, address);
+        this.jYoke.listen(port, address);
+    }
 };
 
 module.exports = JSYoke;

--- a/src/test/resources/integration_tests/jsyoke_tests.js
+++ b/src/test/resources/integration_tests/jsyoke_tests.js
@@ -24,5 +24,24 @@ function testJS() {
     });
 }
 
+function testJSListenToServer() {
+
+    var server = vertx.createHttpServer();
+    var yoke = new Yoke();
+    // all resources are forbidden
+    yoke.use(function (req, next) {
+        next(401);
+    });
+
+    yoke.listen(server);
+    server.listen(8080);
+
+    // The server is listening so send an HTTP request
+    vertx.createHttpClient().port(8080).getNow("/", function(resp) {
+        vassert.assertTrue(401 == resp.statusCode());
+        vassert.testComplete();
+    });
+}
+
 vertxTests.startTests(this);
 


### PR DESCRIPTION
This patch enables JavaScript to pass a server object to `yoke.listen()`.

The method to check if the first parameter to `listen()` is a server object is declared private in `io.vertx~lang-rhino~2.0.0-CR1/vertx/http.js` so we maybe have to bug upstream at some point in the future if the method disappears for some reason... ;)
