### PR TITLE
Refactor and enhance the BodyParser

### DIFF
--- a/framework/src/main/java/com/jetdrone/vertx/yoke/test/YokeTester.java
+++ b/framework/src/main/java/com/jetdrone/vertx/yoke/test/YokeTester.java
@@ -127,13 +127,17 @@ public class YokeTester {
 
                 @Override
                 public HttpServerRequest bodyHandler(Handler<Buffer> bodyHandler) {
-                    bodyHandler.handle(body);
+                    if(bodyHandler != null){
+                        bodyHandler.handle(body);
+                    }
                     return this;
                 }
 
                 @Override
                 public HttpServerRequest dataHandler(Handler<Buffer> handler) {
-                    handler.handle(body);
+                    if(handler != null){
+                        handler.handle(body);
+                    }
                     return this;
                 }
 
@@ -149,7 +153,9 @@ public class YokeTester {
 
                 @Override
                 public HttpServerRequest endHandler(Handler<Void> endHandler) {
-                    endHandler.handle(null);
+                    if(endHandler != null){
+                        endHandler.handle(null);
+                    }
                     return this;
                 }
                 @Override


### PR DESCRIPTION
I may have gone a little overboard on my refactoring. If you'd like me to fix anything or undo one of my refactors, let me know - I'll be glad to. 

I added one feature: If the content type is unknown or not provided, I save the body as a `Buffer`. Previously, it was being thrown away.

I added a test for it.

Here's a list of my refactors:
- Generally repleaced large if/else blocks with if-return blocks
- `parseJson`: Flattened nested try/catch decode exception blocks
- extracted `hasNoBody` to communicate a lack of body
- Replaced `isJSON/is...` boolean fields with an enum for all of the handled content types
- Extracted the upload handler block into it's own method
- Extracted the data handler block into it's own method
- Disabled the data handler if we aren't putting stuff into the buffer
