### PR TITLE
Custom sessionId

### DIFF
--- a/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/YokeRequest.java
+++ b/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/YokeRequest.java
@@ -64,7 +64,7 @@ public class YokeRequest implements HttpServerRequest {
     // is this request secure
     private final boolean secure;
     // session data store
-    private final SessionStore store;
+    protected final SessionStore store;
 
     // we can overrride the setMethod
     private String method;
@@ -350,6 +350,17 @@ public class YokeRequest implements HttpServerRequest {
      */
     public JsonObject createSession() {
         final String sessionId = UUID.randomUUID().toString();
+        return createSession(sessionId);
+    }
+
+    /** Create a new Session with custom Id and store it with the underlying storage.
+     * Internally create a entry in the request context under the name "session" and add a end handler to save that
+     * object once the execution is terminated. Custom session id could be used with external auth provider like mod-auth-mgr.
+     *
+     * @param sessionId custom session id
+     * @return {JsonObject} session
+     */
+    public JsonObject createSession(final String sessionId) {
         final JsonObject session = new JsonObject().putString("id", sessionId);
 
         put("session", session);


### PR DESCRIPTION
I recently updated Yoke and found custom sessionId support was removed. It's required by [mod-auth-mgr](https://github.com/vert-x/mod-auth-mgr) I'm using with Yoke so adding it back. Also making session store protected for possible extended usage.

Paulo, thank you a lot for the hours spent of this framework, please consider adding more extensibility. Currently the code has almost all variables and methods private leading to dirty hacks and full classes copy-pasting instead of neat extension. By now Yoke is the best web framework for vertx, thanks again for your work.
