### PR TITLE
fixed NPE in regex pattern matcher of YokeResponse 

### DIFF
--- a/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/YokeResponse.java
+++ b/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/YokeResponse.java
@@ -296,7 +296,8 @@ public class YokeResponse implements HttpServerResponse {
             // if there is a filter then set the right header
             if (filter != null) {
                 // verify if the filter can filter this content
-                if (filter.canFilter(response.headers().get("content-type"))) {
+                String contentType = response.headers().get("content-type");
+                if (contentType != null && filter.canFilter(contentType)) {
                     response.putHeader("content-encoding", filter.encoding());
                 } else {
                     // disable the filter


### PR DESCRIPTION
A NPE is raised in case the Compress middleware is in the chain however no content-type has been set. The NPE occurs in the regex pattern matcher within "filter.canFilter", as "null" is passed as input value.