### PR TITLE
JsonStore should return 404 when an item is not found

### DIFF
--- a/middleware/reststore/src/main/java/com/jetdrone/vertx/yoke/middleware/JsonStore.java
+++ b/middleware/reststore/src/main/java/com/jetdrone/vertx/yoke/middleware/JsonStore.java
@@ -283,16 +283,18 @@ public class JsonStore extends Router {
                         }
 
                         final JsonArray result = reply.getArray("value");
-                        if (result == null) {
+                        if (result == null || result.size() == 0) {
+                            next.handle(404);
+                            return;
+                        }
+
+                        final JsonObject item = result.get(0);
+                        if (item == null) {
                             next.handle(404);
                         } else {
-                            final JsonObject item = result.get(0);
-                            if (item == null) {
-                                next.handle(404);
-                            } else {
-                                request.response().end(item);
-                            }
+                            request.response().end(item);
                         }
+
                     }
                 });
             }


### PR DESCRIPTION
When getting one item (GET /resource/:id), if the item is not found, the code returns an OutOfBoundException and no response is returned.

Updated this to return 404 instead.