### PR TITLE
make parse and format date thread safe in static middleware

### DIFF
--- a/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/Static.java
+++ b/framework/src/main/java/com/jetdrone/vertx/yoke/middleware/Static.java
@@ -129,7 +129,7 @@ public class Static extends Middleware {
         }
 
         if (!headers.contains("date")) {
-            headers.set("date", ISODATE.format(new Date()));
+            headers.set("date", format(new Date()));
         }
 
         if (!headers.contains("cache-control")) {
@@ -137,7 +137,29 @@ public class Static extends Middleware {
         }
 
         if (!headers.contains("last-modified")) {
-            headers.set("last-modified", ISODATE.format(props.lastModifiedTime()));
+            headers.set("last-modified", format(props.lastModifiedTime()));
+        }
+    }
+
+    /**
+     * Parse thread safe a string to date using a SimpleDateFormat
+     *
+     * @param source
+     * @throws ParseException
+     */
+    private Date parse(String source) throws ParseException {
+        synchronized (ISODATE) {
+            return ISODATE.parse(source);
+        }
+    }
+
+    /**
+     * Convert thread safe a date to a string  using a SimpleDateFormat
+     * @param date
+     */
+    private String format(Date date) {
+        synchronized (ISODATE) {
+            return ISODATE.format(date);
         }
     }
 
@@ -313,8 +335,8 @@ public class Static extends Middleware {
         // if-modified-since
         if (modifiedSince != null) {
             try {
-                Date modifiedSinceDate = ISODATE.parse(modifiedSince);
-                Date lastModifiedDate = ISODATE.parse(lastModified);
+                Date modifiedSinceDate = parse(modifiedSince);
+                Date lastModifiedDate = parse(lastModified);
                 notModified = lastModifiedDate.getTime() <= modifiedSinceDate.getTime();
             } catch (ParseException e) {
                 notModified = false;


### PR DESCRIPTION
I tried to write a unit test but unfortunately I did not caught the error in unit test.

Here is a stacktrace that we get:
java.lang.NumberFormatException: multiple points
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1110)
	at java.lang.Double.parseDouble(Double.java:540)
	at java.text.DigitList.getDouble(DigitList.java:168)
	at java.text.DecimalFormat.parse(DecimalFormat.java:1321)
	at java.text.SimpleDateFormat.subParse(SimpleDateFormat.java:1793)
	at java.text.SimpleDateFormat.parse(SimpleDateFormat.java:1455)
	at java.text.DateFormat.parse(DateFormat.java:355)
	at com.jetdrone.vertx.yoke.middleware.Static.isFresh(Static.java:316)
	at com.jetdrone.vertx.yoke.middleware.Static.access$5(Static.java:280)
	at com.jetdrone.vertx.yoke.middleware.Static$2$1.handle(Static.java:388)
	at com.jetdrone.vertx.yoke.middleware.Static$2$1.handle(Static.java:1)
	at org.vertx.java.core.impl.DefaultFutureResult.checkCallHandler(DefaultFutureResult.java:122)
	at org.vertx.java.core.impl.DefaultFutureResult.setHandler(DefaultFutureResult.java:96)
	at org.vertx.java.core.impl.BlockingAction$1$1.run(BlockingAction.java:57)
	at org.vertx.java.core.impl.DefaultContext$3.run(DefaultContext.java:175)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:370)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
	at java.lang.Thread.run(Thread.java:745)